### PR TITLE
Fix urllib import for python 3.x

### DIFF
--- a/antipackage.py
+++ b/antipackage.py
@@ -16,9 +16,14 @@ anytime they change on GitHub.
 from __future__ import print_function
 import os
 import sys
-from urllib import urlretrieve
 import hashlib
 import shutil
+# Imports for urllib are different in py2 vs. py3
+try: 
+    from urllib import urlretrieve
+except ImportError:
+    from urllib.request import urlretrieve
+
 
 class InstallError(Exception):
     pass


### PR DESCRIPTION
The following import doesn't work in Python 3.x. 

```
from urllib import urlretrieve 
```

`urlretrieve` has been moved into the `urllib.request` module. Here's a quick and simple fix! 
